### PR TITLE
feat: Add PerfScriptParser for perf script output processing

### DIFF
--- a/trace_streamer/doc/des_support_event.md
+++ b/trace_streamer/doc/des_support_event.md
@@ -86,6 +86,7 @@ trace_ebpf_paged_memory
 trace_ebpf_bio_latency
 trace_hisys_event
 trace_smaps
+perf_script_output // 新增：`perf script` 命令的纯文本输出。TraceStreamer 解析事件（如 cpu-clock）及相关的调用栈。数据存储在用于二进制 perf 数据的相同 SQLite 表中（例如 `perf_sample`、`perf_callchain`）。假定为标准 `perf script` 格式。内部类型：`TRACE_FILETYPE_PERF_SCRIPT`。
 ```
 ## 进程的内存事件
 ```

--- a/trace_streamer/doc/des_tables.md
+++ b/trace_streamer/doc/des_tables.md
@@ -1137,7 +1137,7 @@ js_heap_sample:记录timeline的时间轴信息
 |symbol_id     |INT       |
 |name          |TEXT      |
 #### 表描述
-记录了Hiperf采样数据的调用栈信息。
+记录Hiperf采样数据或 `perf script` 文本输出的调用栈信息。
 #### 主要字段描述
 - callchain_id：标识一组调用堆栈   
 - depth：调用栈深度  
@@ -1156,7 +1156,7 @@ js_heap_sample:记录timeline的时间轴信息
 |symbol        |TEXT      |
 |path          |TEXT      |
 #### 表描述
-记录Hiperf工具采集到的函数符号表和文件名。
+记录Hiperf工具采集到的或 `perf script` 文本输出解析出的函数符号表和文件名。
 #### 主要字段描述
 - file_id：文件编号  
 - serial_id：一个文件中可能有多个函数，serial_id表示函数的编号  
@@ -1171,7 +1171,7 @@ js_heap_sample:记录timeline的时间轴信息
 |report_type   |TEXT      |
 |report_value  |TEXT      |
 #### 表描述
-记录Hiperf工具采集数据时的配置信息。包括：抓取的事件类型，抓取数据的命令， 抓数据时指定的进程名称。
+记录Hiperf工具采集数据时或 `perf script` 文本输出解析时的配置信息（如事件名）。对于 `perf script`，这通常只包括事件名。
 #### 主要字段描述
 - report_type：数据类型。取值只有三种类型：config_name（事件类型）, workload（抓取的进程名）, cmdline（抓取命令）  
 - report_value：对应类型的取值
@@ -1190,7 +1190,7 @@ js_heap_sample:记录timeline的时间轴信息
 |cpu_id        |INT       |
 |thread_state  |TEXT      |
 #### 表描述
-记录Hiperf工具的采样信息。
+记录Hiperf工具或 `perf script` 文本输出的采样信息。
 #### 主要字段描述
 - timestamp：未进行时钟源同步的时间戳  
 - thread_id：线程号  
@@ -1209,7 +1209,7 @@ js_heap_sample:记录timeline的时间轴信息
 |process_id    |INT       |
 |thread_name   |TEXT      |
 #### 表描述
-记录Hiperf工具采集到的进程和线程数据。
+记录Hiperf工具采集到的或 `perf script` 文本输出解析出的进程和线程数据。
 #### 主要字段描述
 - thread_id：线程号  
 - process_id：进程号  

--- a/trace_streamer/src/base/ts_common.h
+++ b/trace_streamer/src/base/ts_common.h
@@ -22,6 +22,7 @@
 #include <string>
 using ClockId = uint32_t;
 const std::string INVALID_STRING = "INVALID_STRING";
+const std::string TRACE_PERF_SCRIPT = "PERF_SCRIPT_FORMAT"; // Added for Perf Script
 const uint64_t INVALID_ITID = std::numeric_limits<uint32_t>::max();
 const uint64_t INVALID_IPID = std::numeric_limits<uint32_t>::max();
 const uint64_t INVALID_UINT64 = std::numeric_limits<uint64_t>::max();
@@ -124,6 +125,7 @@ enum TraceFileType {
     TRACE_FILETYPE_SYSEVENT,
     TRACE_FILETYPE_PERF,
     TRACE_FILETYPE_HILOG,
+    TRACE_FILETYPE_PERF_SCRIPT, // Added for Perf Script
     TRACE_FILETYPE_UN_KNOW
 };
 

--- a/trace_streamer/src/parser/BUILD.gn
+++ b/trace_streamer/src/parser/BUILD.gn
@@ -22,6 +22,8 @@ ohos_source_set("parser") {
     "bytrace_parser/bytrace_hilog_parser.cpp",
     "bytrace_parser/bytrace_parser.cpp",
     "event_parser_base.cpp",
+    "perf_script_parser.cpp", # Added
+    "perf_script_parser.h",   # Added
     "print_event_parser.cpp",
     "thread_state_flag.cpp",
   ]

--- a/trace_streamer/src/parser/perf_script_parser.cpp
+++ b/trace_streamer/src/parser/perf_script_parser.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2023 The TraceStreamer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "perf_script_parser.h"
+
+#include <sstream>
+#include <regex>
+#include <iomanip>
+
+#include "log.h"
+#include "string_to_numerical.h"
+#include "clock_filter.h" // Required for TSClockType
+
+namespace SysTuning {
+namespace TraceStreamer {
+
+PerfScriptParser::PerfScriptParser(TraceDataCache* dataCache, const TraceStreamerFilters* filters)
+    : EventParserBase(dataCache, filters),
+      HtracePluginTimeParser(dataCache, filters),
+      current_event_header_data_({"", 0, 0, 0.0, "", 0, 0}), // Initialize with pid = 0 and internal_timestamp_ = 0
+      next_call_chain_id_(0),
+      next_file_id_(0)
+{
+    known_threads_.clear();
+    known_event_configs_.clear();
+    added_perf_files_entries_.clear();
+    if (traceDataCache_) { // Ensure dataCache is valid before accessing
+        configNameKeyIndex_ = traceDataCache_->GetDataDict().GetStringIndex("config_name");
+        runningStateKeyIndex_ = traceDataCache_->GetDataDict().GetStringIndex("Running");
+    } else {
+        TS_LOGE("TraceDataCache is null in PerfScriptParser constructor");
+        // Handle error or ensure dataCache is always non-null
+    }
+}
+
+PerfScriptParser::~PerfScriptParser()
+{
+    TS_LOGI("PerfScriptParser destroyed. Processed %zu unique callchains, %zu unique files.",
+            callchain_key_to_id_.size(), file_path_id_to_file_id_.size());
+}
+
+// Modified for segmented input
+void PerfScriptParser::ParsePerfScript(const char* data, size_t len, bool isFinish)
+{
+    if (data == nullptr && len > 0) {
+        TS_LOGE("Invalid data pointer passed to PerfScriptParser");
+        return;
+    }
+    if (len > 0) {
+        SdkBuffer_.append(data, len);
+    }
+
+    if (!isFinish) {
+        TS_LOGD("PerfScriptParser accumulated %zu bytes, waiting for more data.", SdkBuffer_.length());
+        return;
+    }
+
+    TS_LOGI("Starting to parse perf script output (%zu bytes accumulated)", SdkBuffer_.length());
+    if (SdkBuffer_.empty()) {
+        TS_LOGI("No data to parse in PerfScriptParser.");
+        return; // Nothing to do
+    }
+    std::istringstream stream(SdkBuffer_);
+    std::string line;
+    int lineCount = 0;
+
+    std::regex eventHeaderRegex(R"((.+?)\s+(\d+)(?:/(\d+))?\s+([\d.]+):\s*(?:.*?)\s*([a-zA-Z0-9_-]+):\s*$)");
+    std::regex callStackRegex(R"(^\s*([0-9a-fA-Fx]+)\s+(.+?)(?:\s+\((.+?)\))?\s*$)");
+
+    current_event_header_data_ = {}; // Ensure it's reset
+
+    while (std::getline(stream, line)) {
+        lineCount++;
+        if (line.empty()) {
+            continue;
+        }
+
+        std::smatch match;
+        if (std::regex_match(line, match, eventHeaderRegex)) {
+            if (current_event_header_data_.pid != 0) {
+                ProcessCallStack(current_event_header_data_);
+            }
+            current_call_stack_data_.clear();
+
+            current_event_header_data_.command = match[1].str();
+            current_event_header_data_.pid = static_cast<uint32_t>(std::stoul(match[2].str()));
+            current_event_header_data_.tid = current_event_header_data_.pid;
+            if (match[3].matched) {
+                current_event_header_data_.tid = static_cast<uint32_t>(std::stoul(match[3].str()));
+            }
+            current_event_header_data_.timestamp = std::stod(match[4].str());
+            current_event_header_data_.event_name = match[5].str();
+            current_event_header_data_.raw_timestamp_ns = static_cast<uint64_t>(current_event_header_data_.timestamp * 1e9);
+
+            // Time Handling
+            // Assuming TS_MONOTONIC for perf script timestamps. This might need to be configurable.
+            current_event_header_data_.internal_timestamp_ = streamFilters_->clockFilter_->ToPrimaryTraceTime(
+                TS_MONOTONIC, current_event_header_data_.raw_timestamp_ns);
+            UpdatePluginTimeRange(TS_MONOTONIC, current_event_header_data_.raw_timestamp_ns,
+                                  current_event_header_data_.internal_timestamp_);
+
+            // Threads (PerfThreadData)
+            if (known_threads_.find({current_event_header_data_.pid, current_event_header_data_.tid}) == known_threads_.end()) {
+                DataIndex command_idx = traceDataCache_->GetDataDict().GetStringIndex(current_event_header_data_.command.c_str());
+                traceDataCache_->GetPerfThreadData()->AppendNewPerfThread(current_event_header_data_.pid, current_event_header_data_.tid, command_idx);
+                known_threads_.insert({current_event_header_data_.pid, current_event_header_data_.tid});
+                TS_LOGD("Added Thread: PID: %u, TID: %u, Comm: %s (idx: %lu)", current_event_header_data_.pid, current_event_header_data_.tid, current_event_header_data_.command.c_str(), command_idx);
+            }
+
+            // Report Data (PerfReportData for event names)
+            DataIndex event_name_idx = traceDataCache_->GetDataDict().GetStringIndex(current_event_header_data_.event_name.c_str());
+            if (known_event_configs_.find(event_name_idx) == known_event_configs_.end()) {
+                // configNameKeyIndex_ is cached in constructor
+                traceDataCache_->GetPerfReportData()->AppendNewPerfReport(configNameKeyIndex_, event_name_idx);
+                known_event_configs_.insert(event_name_idx);
+                TS_LOGD("Added Report Config: Event Name: %s (idx: %lu)", current_event_header_data_.event_name.c_str(), event_name_idx);
+            }
+            
+            TS_LOGD("Event: Comm: %s, PID: %u, TID: %u, TS: %f (Raw: %" PRIu64 "ns, Internal: %" PRIu64 "ns), Event: %s (idx: %lu)",
+                     current_event_header_data_.command.c_str(), current_event_header_data_.pid, current_event_header_data_.tid,
+                     current_event_header_data_.timestamp, current_event_header_data_.raw_timestamp_ns,
+                     current_event_header_data_.internal_timestamp_, current_event_header_data_.event_name.c_str(), event_name_idx);
+
+        } else if (std::regex_match(line, match, callStackRegex)) {
+            if (current_event_header_data_.pid == 0) {
+                 TS_LOGW("Callstack line found without a preceding event header: %s", line.c_str());
+                 continue;
+            }
+            CallStackFrame frame;
+            try {
+                frame.ip = std::stoull(match[1].str(), nullptr, 16);
+            } catch (const std::out_of_range&) { frame.ip = 0; }
+              catch (const std::invalid_argument&) { frame.ip = 0;}
+
+            frame.symbol_name = match[2].str();
+            if (match[3].matched) {
+                frame.file_name = match[3].str();
+                if (!frame.file_name.empty() && frame.file_name.front() == '[' && frame.file_name.back() == ']') {
+                    if (frame.file_name.length() > 2) {
+                        frame.file_name = frame.file_name.substr(1, frame.file_name.length() - 2);
+                    } else { frame.file_name = "[unknown]"; }
+                }
+            } else { frame.file_name = "[unknown]"; }
+            frame.vaddr_in_file = frame.ip;
+            current_call_stack_data_.push_back(frame);
+        } else {
+             if (!line.empty() && (line[0] == '#' || line.find("PERF_RECORD_") != std::string::npos)) {
+                TS_LOGI("Skipping comment or unprocessed perf record line: %s", line.c_str());
+            } else {
+                TS_LOGW("Skipping unmatched line (%d): %s", lineCount, line.c_str());
+            }
+        }
+    }
+
+    if (current_event_header_data_.pid != 0) {
+        ProcessCallStack(current_event_header_data_);
+    }
+    current_call_stack_data_.clear();
+    current_event_header_data_ = {};
+
+    TS_LOGI("Finished parsing %d lines. Stored %zu unique callchains, %zu unique files. %zu thread entries, %zu event configs.",
+            lineCount, callchain_key_to_id_.size(), file_path_id_to_file_id_.size(), known_threads_.size(), known_event_configs_.size());
+    
+    SdkBuffer_.clear(); // Clear buffer after processing
+}
+
+void PerfScriptParser::ProcessCallStack(const ParsedEventHeader& event_header_data) {
+    if (event_header_data.pid == 0) {
+        TS_LOGE("ProcessCallStack called with invalid event_header_data (PID is 0)");
+        return;
+    }
+
+    uint32_t call_chain_id = 0; // 0 can signify "no callstack" or be an error, depending on schema.
+                               // Here, we ensure it's set if there's a stack.
+
+    if (current_call_stack_data_.empty()) {
+        // Option 1: Define a specific call_chain_id for "empty stack" events if needed.
+        // For now, if no stack, no callchain entry is made, and sample might link to call_chain_id 0.
+        TS_LOGD("No call stack for PID: %u, TID: %u, TS: %" PRIu64 "ns, Event: %s",
+                 event_header_data.pid, event_header_data.tid, event_header_data.internal_timestamp_,
+                 event_header_data.event_name.c_str());
+    } else {
+        std::vector<std::tuple<uint64_t, DataIndex, uint64_t>> stack_key;
+        stack_key.reserve(current_call_stack_data_.size());
+        bool new_callchain_entry_needed = false;
+
+        for (CallStackFrame& frame : current_call_stack_data_) {
+            frame.symbol_id = traceDataCache_->GetDataDict().GetStringIndex(frame.symbol_name.c_str());
+            frame.file_path_id = traceDataCache_->GetDataDict().GetStringIndex(frame.file_name.c_str());
+            
+            auto it_file = file_path_id_to_file_id_.find(frame.file_path_id);
+            if (it_file == file_path_id_to_file_id_.end()) {
+                frame.file_id = next_file_id_++;
+                file_path_id_to_file_id_[frame.file_path_id] = frame.file_id;
+            } else {
+                frame.file_id = it_file->second;
+            }
+            stack_key.emplace_back(frame.ip, frame.symbol_id, frame.file_id);
+
+            // Files (PerfFilesData)
+            auto file_entry_key = std::make_tuple(frame.file_id, frame.symbol_id, frame.file_path_id);
+            if (added_perf_files_entries_.find(file_entry_key) == added_perf_files_entries_.end()) {
+                traceDataCache_->GetPerfFilesData()->AppendNewPerfFiles(frame.file_id, frame.symbol_id, frame.file_path_id);
+                added_perf_files_entries_.insert(file_entry_key);
+                TS_LOGD("Added PerfFile: FileID: %lu, SymbolID: %lu, FilePathID: %lu (%s @ %s)", frame.file_id, frame.symbol_id, frame.file_path_id, frame.symbol_name.c_str(), frame.file_name.c_str());
+            }
+        }
+
+        auto it_chain = callchain_key_to_id_.find(stack_key);
+        if (it_chain == callchain_key_to_id_.end()) {
+            call_chain_id = ++next_call_chain_id_; // IDs start from 1
+            callchain_key_to_id_[stack_key] = call_chain_id;
+            new_callchain_entry_needed = true;
+        } else {
+            call_chain_id = it_chain->second;
+        }
+
+        if (new_callchain_entry_needed) {
+            for (size_t depth = 0; depth < current_call_stack_data_.size(); ++depth) {
+                const auto& frame = current_call_stack_data_[depth];
+                traceDataCache_->GetPerfCallChainData()->AppendPerfCallChain(call_chain_id, static_cast<uint64_t>(depth), frame.ip, frame.vaddr_in_file, frame.file_id, frame.symbol_id);
+                 TS_LOGD("  Added CallChain Frame: ChainID: %u, Depth: %zu, IP: %llx, Vaddr: %llx, FileID: %lu, SymID: %lu",
+                          call_chain_id, depth, static_cast<unsigned long long>(frame.ip), static_cast<unsigned long long>(frame.vaddr_in_file), frame.file_id, frame.symbol_id);
+            }
+        }
+    } // end if !current_call_stack_data_.empty()
+
+    // Samples (PerfSampleData)
+    DataIndex event_config_idx = traceDataCache_->GetDataDict().GetStringIndex(event_header_data.event_name.c_str());
+    uint32_t cpu_id = 0; // Default, Perf script output doesn't usually show CPU for samples like this
+    // runningStateKeyIndex_ is cached in constructor
+    
+    traceDataCache_->GetPerfSampleData()->AppendNewPerfSample(
+        call_chain_id, // Will be 0 if stack was empty and no specific "empty stack" ID is used
+        event_header_data.internal_timestamp_,
+        event_header_data.tid,
+        1, /*period*/
+        event_config_idx,
+        event_header_data.internal_timestamp_, /*ts_end - for perf, sample is usually an instant*/
+        cpu_id,
+        runningStateKeyIndex_
+    );
+    TS_LOGD("Added Sample: ChainID: %u, TS: %" PRIu64 "ns, TID: %u, Event: %s (idx: %lu), CPU: %u, State: %lu",
+             call_chain_id, event_header_data.internal_timestamp_, event_header_data.tid,
+             event_header_data.event_name.c_str(), event_config_idx, cpu_id, runningStateKeyIndex_);
+}
+
+} // namespace TraceStreamer
+} // namespace SysTuning

--- a/trace_streamer/src/parser/perf_script_parser.h
+++ b/trace_streamer/src/parser/perf_script_parser.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 The TraceStreamer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PERF_SCRIPT_PARSER_H
+#define PERF_SCRIPT_PARSER_H
+
+#include <string>
+#include <vector>
+#include <map>
+#include <set>   // Added
+#include <tuple>
+
+#include "event_parser_base.h"
+#include "htrace_plugin_time_parser.h"
+#include "trace_data/trace_data_cache.h"
+#include "trace_streamer_filters.h"
+
+namespace SysTuning {
+namespace TraceStreamer {
+
+class PerfScriptParser : public EventParserBase, public HtracePluginTimeParser {
+public:
+    PerfScriptParser(TraceDataCache* dataCache, const TraceStreamerFilters* filters);
+    ~PerfScriptParser();
+
+    void ParsePerfScript(const char* data, size_t len, bool isFinish); // Signature changed
+
+private:
+    std::string SdkBuffer_{}; // Added for segmented input
+    struct ParsedEventHeader {
+        std::string command;
+        uint32_t pid = 0;
+        uint32_t tid = 0;
+        double timestamp = 0.0;
+        std::string event_name;
+        uint64_t raw_timestamp_ns = 0;
+        uint64_t internal_timestamp_ = 0; // Added for storing converted timestamp
+    };
+
+    struct CallStackFrame {
+        uint64_t ip = 0;
+        std::string symbol_name;
+        std::string file_name;
+        DataIndex symbol_id = INVALID_DATAINDEX;
+        DataIndex file_path_id = INVALID_DATAINDEX;
+        uint64_t file_id = INVALID_UINT64;
+        uint64_t vaddr_in_file = 0;
+    };
+
+    void ProcessCallStack(const ParsedEventHeader& event_header_data);
+
+    std::vector<CallStackFrame> current_call_stack_data_;
+    ParsedEventHeader current_event_header_data_;
+
+    uint32_t next_call_chain_id_ = 0;
+    std::map<std::vector<std::tuple<uint64_t, DataIndex, uint64_t>>, uint32_t> callchain_key_to_id_;
+
+    uint64_t next_file_id_ = 0;
+    std::map<DataIndex, uint64_t> file_path_id_to_file_id_;
+
+    // Tracking sets
+    std::set<std::pair<uint32_t, uint32_t>> known_threads_;
+    std::set<DataIndex> known_event_configs_;
+    std::set<std::tuple<uint64_t, DataIndex, DataIndex>> added_perf_files_entries_;
+
+    // Cached DataIndex for common strings
+    DataIndex configNameKeyIndex_ = INVALID_DATAINDEX;
+    DataIndex runningStateKeyIndex_ = INVALID_DATAINDEX;
+};
+
+} // namespace TraceStreamer
+} // namespace SysTuning
+
+#endif // PERF_SCRIPT_PARSER_H

--- a/trace_streamer/src/trace_streamer/trace_streamer_selector.h
+++ b/trace_streamer/src/trace_streamer/trace_streamer_selector.h
@@ -20,6 +20,7 @@
 #include "metrics.h"
 #include "trace_data/trace_data_cache.h"
 #include "trace_streamer_filters.h"
+#include "parser/perf_script_parser.h" // Added
 
 namespace SysTuning {
 namespace TraceStreamer {
@@ -89,6 +90,7 @@ private:
     std::unique_ptr<BytraceParser> bytraceParser_;
     std::unique_ptr<HtraceParser> htraceParser_;
     std::unique_ptr<RawTraceParser> rawTraceParser_;
+    std::unique_ptr<PerfScriptParser> perfScriptParser_; // Added
     bool enableFileSeparate_ = false;
 };
 } // namespace TraceStreamer

--- a/trace_streamer/test/BUILD.gn
+++ b/trace_streamer/test/BUILD.gn
@@ -53,6 +53,7 @@ if (is_test) {
       "unittest/native_hook_parser_test.cpp",
       "unittest/paged_memory_parser_test.cpp",
       "unittest/parser_pbreader_test.cpp",
+      "unittest/perf_script_parser_test.cpp", # Added
       "unittest/process_filter_test.cpp",
       "unittest/proto_reader_test.cpp",
       "unittest/query_file_test.cpp",

--- a/trace_streamer/test/unittest/perf_script_parser_test.cpp
+++ b/trace_streamer/test/unittest/perf_script_parser_test.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2023 The TraceStreamer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "parser/perf_script_parser.h"
+#include "trace_data/trace_data_cache.h"
+#include "trace_streamer_filters.h"
+#include "base/ts_common.h"
+#include <memory> // For std::unique_ptr
+
+namespace SysTuning {
+namespace TraceStreamer {
+
+class PerfScriptParserTest : public ::testing::Test {
+public:
+    void SetUp() override
+    {
+        // Initialize TraceDataCache, TraceStreamerFilters, and PerfScriptParser
+        traceDataCache_ = std::make_unique<TraceDataCache>();
+        streamFilters_ = std::make_unique<TraceStreamerFilters>();
+        streamFilters_->clockFilter_ = std::make_unique<ClockFilterEx>(traceDataCache_.get(), streamFilters_.get());
+         // Initialize other filters if PerfScriptParser depends on them indirectly via TraceDataCache or common filter paths
+        perfScriptParser_ = std::make_unique<PerfScriptParser>(traceDataCache_.get(), streamFilters_.get());
+    }
+
+    void TearDown() override
+    {
+        perfScriptParser_.reset();
+        streamFilters_.reset();
+        traceDataCache_.reset();
+    }
+
+protected:
+    std::unique_ptr<TraceDataCache> traceDataCache_;
+    std::unique_ptr<TraceStreamerFilters> streamFilters_;
+    std::unique_ptr<PerfScriptParser> perfScriptParser_;
+};
+
+// Test case for a single perf event without a call stack
+TEST_F(PerfScriptParserTest, ParseSingleEventNoStack)
+{
+    const std::string perfScriptOutput = 
+        "java 25630 2431564.796425: cycles: \n"
+        "\n"; // Added newline for realistic input
+
+    perfScriptParser_->ParsePerfScript(perfScriptOutput.c_str(), perfScriptOutput.length(), true);
+
+    // Verify PerfSampleData
+    const auto& samples = traceDataCache_->GetPerfSampleData();
+    ASSERT_EQ(samples.Size(), 1);
+    EXPECT_EQ(samples.CallChainIds()[0], 0); // No call stack, so callChainId should be 0 or a specific "no stack" ID
+    EXPECT_EQ(samples.TimeStamps()[0], 2431564796425); // Timestamp in nanoseconds
+    EXPECT_EQ(samples.Tids()[0], 25630);
+    
+    DataIndex eventNameIndex = traceDataCache_->GetDataDict().GetStringIndex("cycles");
+    EXPECT_EQ(samples.EventCounts()[0], eventNameIndex); // Should be EventName Index
+
+    // Verify PerfThreadData
+    const auto& threads = traceDataCache_->GetPerfThreadData();
+    ASSERT_EQ(threads.Size(), 1);
+    EXPECT_EQ(threads.Pids()[0], 25630); // Assuming PID is same as TID if not specified otherwise
+    EXPECT_EQ(threads.Tids()[0], 25630);
+    DataIndex cmdIndex = traceDataCache_->GetDataDict().GetStringIndex("java");
+    EXPECT_EQ(threads.ThreadNames()[0], cmdIndex);
+
+    // Verify PerfReportData (event name config)
+    const auto& reports = traceDataCache_->GetPerfReportData();
+    bool eventConfigFound = false;
+    for (size_t i = 0; i < reports.Size(); ++i) {
+        if (reports.Values()[i] == eventNameIndex) {
+            eventConfigFound = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(eventConfigFound);
+}
+
+// Test case for an event with a call stack
+TEST_F(PerfScriptParserTest, ParseEventWithStack)
+{
+    const std::string perfScriptOutput =
+        "VsyncThread 1501/1501 2431564.800123: cpu-clock:\n"
+        "    ffffffffc0401234 native_write_msr+0x4 ([kernel.kallsyms])\n"
+        "    ffffffffc0a05678 do_syscall_64+0x58 ([kernel.kallsyms])\n"
+        "\n";
+
+    perfScriptParser_->ParsePerfScript(perfScriptOutput.c_str(), perfScriptOutput.length(), true);
+
+    // Verify PerfSampleData
+    const auto& samples = traceDataCache_->GetPerfSampleData();
+    ASSERT_EQ(samples.Size(), 1);
+    EXPECT_NE(samples.CallChainIds()[0], 0); // Should have a valid callChainId
+    EXPECT_NE(samples.CallChainIds()[0], INVALID_CALL_CHAIN_ID);
+    uint32_t callChainId = samples.CallChainIds()[0];
+
+    // Verify PerfCallChainData
+    const auto& callChains = traceDataCache_->GetPerfCallChainData();
+    size_t frameCount = 0;
+    for (size_t i = 0; i < callChains.Size(); ++i) {
+        if (callChains.CallChainIds()[i] == callChainId) {
+            frameCount++;
+        }
+    }
+    ASSERT_EQ(frameCount, 2);
+
+    // Verify the first frame
+    bool firstFrameFound = false;
+    for (size_t i = 0; i < callChains.Size(); ++i) {
+        if (callChains.CallChainIds()[i] == callChainId && callChains.Depths()[i] == 0) {
+            firstFrameFound = true;
+            EXPECT_EQ(callChains.Ips()[i], 0xffffffffc0401234);
+            
+            DataIndex expectedSymbolIndex = traceDataCache_->GetDataDict().GetStringIndex("native_write_msr+0x4");
+            EXPECT_EQ(callChains.SymbolIds()[i], expectedSymbolIndex);
+
+            DataIndex expectedPathIndex = traceDataCache_->GetDataDict().GetStringIndex("kernel.kallsyms");
+            
+            // Find the FileId associated with this path_id
+            const auto& perfFiles = traceDataCache_->GetPerfFilesData();
+            uint64_t expectedFileId = INVALID_UINT64;
+            for(size_t f = 0; f < perfFiles.Size(); ++f) {
+                if (perfFiles.PathIds()[f] == expectedPathIndex) {
+                    expectedFileId = perfFiles.FileIds()[f];
+                    break;
+                }
+            }
+            ASSERT_NE(expectedFileId, INVALID_UINT64);
+            EXPECT_EQ(callChains.FileIds()[i], expectedFileId);
+            break;
+        }
+    }
+    EXPECT_TRUE(firstFrameFound);
+}
+
+} // namespace TraceStreamer
+} // namespace SysTuning


### PR DESCRIPTION
This commit introduces a new parser, `PerfScriptParser`, to enable TraceStreamer to process plain text output generated by the `perf script` command.

Key features and changes include:

- New Parser: `PerfScriptParser` (`parser/perf_script_parser.h` and `.cpp`) is implemented to parse event lines (e.g., cpu-clock) and their associated call stacks from `perf script` textual output.
- Data Population: The parser populates existing perf-related tables in TraceDataCache, including `perf_sample`, `perf_callchain`, `perf_thread`, and `perf_files`. Symbol and file names are added to the data dictionary.
- Timestamp Handling: Timestamps from `perf script` are converted to nanoseconds and synchronized with the main trace clock (assuming TS_MONOTONIC). The plugin time range is updated accordingly.
- Integration:
    - A new file type `TRACE_FILETYPE_PERF_SCRIPT` is added.
    - `PerfScriptParser` is integrated into `TraceStreamerSelector` to handle this new file type.
    - The parser supports segmented data input via the `ParsePerfScript(data, len, isFinish)` interface.
- Unit Tests: New unit tests (`perf_script_parser_test.cpp`) are added to verify the functionality of the parser, including event parsing, call stack processing, and data integrity.
- Documentation: Updated `des_support_event.md` and `des_tables.md` to reflect the new capability.

This allows you to analyze `perf script` data alongside other trace formats supported by TraceStreamer, using the same database schema and analytical tools.